### PR TITLE
モデル層のBehaviorRelayの見直し

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,7 @@ target 'RxSwiftMVVM' do
   pod "RxSwift"
   pod "Moya/RxSwift"
   pod "SwiftLint"
+  pod 'SwiftEventBus'
 
   # Pods for SwiftMVVM
   

--- a/RxSwiftMVVM.xcodeproj/project.pbxproj
+++ b/RxSwiftMVVM.xcodeproj/project.pbxproj
@@ -163,11 +163,11 @@
 			isa = PBXGroup;
 			children = (
 				3E35A1BA20B98A8D00B9AD4F /* LoginViewModel.swift */,
+				3E35A1BF20B98A8D00B9AD4F /* LoginViewController.swift */,
+				3E35A1BE20B98A8D00B9AD4F /* MainViewModel.swift */,
 				3E35A1BB20B98A8D00B9AD4F /* MainViewController.swift */,
 				3E35A1BC20B98A8D00B9AD4F /* SplashViewController.swift */,
 				3E35A1BD20B98A8D00B9AD4F /* SplashViewModel.swift */,
-				3E35A1BE20B98A8D00B9AD4F /* MainViewModel.swift */,
-				3E35A1BF20B98A8D00B9AD4F /* LoginViewController.swift */,
 			);
 			path = "View+ViewModel";
 			sourceTree = "<group>";
@@ -222,6 +222,7 @@
 				3E35A18B20B989B000B9AD4F /* Resources */,
 				1C897BAE962E41E1A44A666A /* [CP] Embed Pods Frameworks */,
 				3E35A1D520B9987A00B9AD4F /* ShellScript */,
+				DFF5D7894AB71AF766826715 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -241,6 +242,7 @@
 				3E35A19E20B989B300B9AD4F /* Frameworks */,
 				3E35A19F20B989B300B9AD4F /* Resources */,
 				18491BA089B6800945D83319 /* [CP] Embed Pods Frameworks */,
+				873E8A2253B342C5302836DC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -324,6 +326,7 @@
 				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftEventBus/SwiftEventBus.framework",
 				"${BUILT_PRODUCTS_DIR}/RxBlocking/RxBlocking.framework",
 				"${BUILT_PRODUCTS_DIR}/RxTest/RxTest.framework",
 			);
@@ -334,6 +337,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftEventBus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxBlocking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxTest.framework",
 			);
@@ -354,6 +358,7 @@
 				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftEventBus/SwiftEventBus.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -362,6 +367,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftEventBus.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -380,6 +386,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which \"${PODS_ROOT}/SwiftLint/swiftlint\" >/dev/null; then\n${PODS_ROOT}/SwiftLint/swiftlint\n${PODS_ROOT}/SwiftLint/swiftlint autocorrect\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		873E8A2253B342C5302836DC /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxSwiftMVVM-RxSwiftMVVMTests/Pods-RxSwiftMVVM-RxSwiftMVVMTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DFF5D7894AB71AF766826715 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxSwiftMVVM/Pods-RxSwiftMVVM-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		F6A49485F2AA7ED81D6A9AC7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/RxSwiftMVVM/APIs/Login.swift
+++ b/RxSwiftMVVM/APIs/Login.swift
@@ -5,5 +5,6 @@
 import Foundation
 
 struct Login: Codable {
-    let result, url: String
+    let result: String
+    let url: String
 }

--- a/RxSwiftMVVM/Model/Auth.swift
+++ b/RxSwiftMVVM/Model/Auth.swift
@@ -6,40 +6,52 @@
 import Foundation
 import RxSwift
 import RxCocoa
+import SwiftEventBus
+
+/// ログイン状態
+struct LoginState {
+    var isLogin = false
+}
 
 class Auth {
 
     static let sheard = Auth()
     init() {
-        userId.accept(Repository.shared.get(.userIDKey))
-        password.accept(Repository.shared.get(.passwordKey))
     }
     
     let disposeBag = DisposeBag()
     let repository = Repository.shared
-    let isLogin = BehaviorRelay<Bool>(value: false)
-    let loginQueue = PublishRelay<Void>()
     
-    let userId = BehaviorRelay<String>(value: "")
-    let password = BehaviorRelay<String>(value: "")
+    /// シングルトンにあっていいんかな？
+    let isLogin = BehaviorRelay<Bool>(value: false)
 
-    func login(name: String, pass: String) {
-        
+    /// ログインのシーケンス
+    //func login(name: String, pass: String) {
+    //    //色々エラー処理・分岐・リトライ・画面遷移通知を行う予定
+    //    ApiService.shard.request(LoginAPIService.login(name, pass))
+    //        .map {$0.result}
+    //        .flatMap {_ -> Single<Login> in  ApiService.shard.request(LoginAPIService.login(name, pass))}
+    //        .map {$0.result == "1"}
+    //        .subscribe(onSuccess: {result in
+    //            self.isLogin.accept(result)
+    //        })
+    //        .disposed(by: disposeBag)
+    //}
+    
+    /// ログインのシーケンス
+    func loginSingle(name: String, pass: String) -> Single<LoginState> {
         //色々エラー処理・分岐・リトライ・画面遷移通知を行う予定
-//        _ = loginQueue
-//            .flatMap { ApiService.shard.request(LoginAPIService.login(name, pass))}
-//            .flatMap { _ -> Single<Login> in ApiService.shard.request(LoginAPIService.login(name, pass))}
-//            .subscribe(onNext: {result in print(result.result) })
-//            .disposed(by: disposeBag)
-        
-        ApiService.shard.request(LoginAPIService.login(name, pass))
+        return ApiService.shard.request(LoginAPIService.login(name, pass))
             .map {$0.result}
-            .flatMap {_ -> Single<Login> in  ApiService.shard.request(LoginAPIService.login(name, pass))}
-            .map {$0.result == "1"}
-            .subscribe(onSuccess: {result in
-                self.isLogin.accept(result)
-            })
-            .disposed(by: disposeBag)
-
+            .flatMap {_ -> Single<Login> in
+                ApiService.shard.request(LoginAPIService.login(name, pass))
+            }
+            .map {
+                LoginState(isLogin: ($0.result == "1"))
+            }
+            .catchError { (error) -> Single<LoginState> in
+                SwiftEventBus.post("VIEW_ERROR_DIALOG")
+                return Single.error(error)
+            }
     }
 }

--- a/RxSwiftMVVM/View+ViewModel/LoginViewController.swift
+++ b/RxSwiftMVVM/View+ViewModel/LoginViewController.swift
@@ -1,9 +1,26 @@
 import UIKit
 import RxCocoa
 import RxSwift
+import SwiftEventBus
+//import UI+RxExtention
+
+extension UITextField {
+    /// テキストボックスとViewModelのストリームを双方向バインディング
+    func setRelay(relay: BehaviorRelay<String?>!, by bag: DisposeBag) {
+        relay.asDriver().drive(self.rx.text).disposed(by: bag)
+        self.rx.text.bind(to: relay).disposed(by: bag)
+    }
+}
+
+extension UIButton {
+    /// タップイベントのバインディング
+    func setEvent(event: (() -> Void)!, by bag: DisposeBag) {
+        self.rx.tap.asObservable().bind(onNext: { () in event() }).disposed(by: bag)
+    }
+}
 
 class LoginViewController: UIViewController {
-
+    
     @IBOutlet weak var userIDTextField: UITextField!
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var loginButton: UIButton!
@@ -13,38 +30,34 @@ class LoginViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         viewModel = LoginViewModel(Auth.sheard)
         
-        viewModel.userId.asDriver()
-                .drive(userIDTextField.rx.text)
-                .disposed(by: disposeBag)
-
-        viewModel.password.asDriver()
-            .drive(passwordTextField.rx.text)
-            .disposed(by: disposeBag)
-
-        userIDTextField.rx.text.asDriver()
-            .drive(viewModel.userId)
-            .disposed(by: disposeBag)
-
-        passwordTextField.rx.text.asDriver()
-            .drive(viewModel.password)
-            .disposed(by: disposeBag)
-
-        loginButton.rx.tap
-            .bind(to: viewModel.loginButtonDidTap)
-            .disposed(by: disposeBag)
+        // データバインディング
+        userIDTextField.setRelay(relay: viewModel.userId, by: disposeBag)
+        passwordTextField.setRelay(relay: viewModel.password, by: disposeBag)
         
-        viewModel.loginSuccess
-            .subscribe(onNext: { segue in
-                self.performSegue(withIdentifier: segue, sender: nil)
-            })
-            .disposed(by: disposeBag)
+        // タップイベント
+        loginButton.setEvent(event: viewModel.loginButtonDidTap, by: disposeBag)
+        
+        // イベントハンドラ登録
+        registEventOnMainThread()
     }
-
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
 
+    /// 遷移・ダイアログ表示系の処理（SwiftEventBusでオブサーブする）
+    func registEventOnMainThread() {
+        // 画面遷移
+        SwiftEventBus.onMainThread(self, name: "EVENTBUS_KEY_SEGUE_MAIN") { _ in
+            self.performSegue(withIdentifier: "main", sender: nil)
+        }
+        // エラーダイアログ表示
+        SwiftEventBus.onMainThread(self, name: "VIEW_ERROR_DIALOG") { _ in
+            // self.viewDialog()
+        }
+    }
 }


### PR DESCRIPTION
* シングルトンなモデル層にBehaviorRelayを持っているのが違和感ある感じです。
→ アプリのロジックがもつ揮発的なキャッシュはVIewModel層からViewController層までに
　しておかないの動きが怪しい気がします。

* `モデル層でエラー → ViewControllerに通知` の部分は
SwiftEventBus でオブサーブするように一旦はしてます。
→ ハンドリングしてエラー処理しての部分は流石にBehaviorRelayは使わない気がします(^_^;)

BehaviorRelayはViewControllerまたいでアグレッシブにしたい時とかは使って良い気がしますが、順次で更新されるので考えて使わないと危険な香りがしますね。
（Auth.swiftを例にすると、userIdとpasswordの完全性が保証できてない。）